### PR TITLE
Adicionando funcionalidade de solicitação de baixa de registro

### DIFF
--- a/cnab240/tipos.py
+++ b/cnab240/tipos.py
@@ -218,9 +218,8 @@ class Arquivo(object):
     def lotes(self):
         return self._lotes
 
-    def incluir_cobranca(self, header, **kwargs):
-        # 1 eh o codigo de cobranca
-        codigo_evento = 1
+    def incluir_evento(self, header, codigo_movimento, **kwargs):
+        codigo_evento = codigo_movimento
         evento = Evento(self.banco, codigo_evento)
 
         seg_p = self.banco.registros.SegmentoP(**kwargs)
@@ -252,6 +251,14 @@ class Arquivo(object):
         lote_cobranca.adicionar_evento(evento)
         # Incrementar numero de registros no trailer do arquivo
         self.trailer.totais_quantidade_registros += len(evento)
+
+    def incluir_cobranca(self, header, **kwargs):
+        # 1 = codigo de cobranca
+        self.incluir_evento(header, 1, **kwargs)
+
+    def incluir_baixa(self, header, **kwargs):
+        # 2 = codigo de solicitacao de baixa
+        self.incluir_evento(header, 2, **kwargs)
 
     def encontrar_lote(self, codigo_servico):
         for lote in self.lotes:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='python-cnab',
-    version='0.1.19',
+    version='0.1.20',
     author='Trustcode',
     author_email='suporte@trustcode.com.br',
     url='https://github.com/Trust-Code/python-cnab',


### PR DESCRIPTION
Implementação de funcionalidade que registra o _comando de baixa título_ de um nosso número já registrado no sistema dos bancos.

Foi pensado em manter a compatibilidade de sistemas que já fazem uso da função `incluir_cobranca`, e adaptando o resto da implementação levando em conta essa premissa.