### PR TITLE
[11.0][FIX(?)] JSON cecred com tag errada, remoção tag repetida

### DIFF
--- a/cnab240/bancos/cecred/specs/segmento_t.json
+++ b/cnab240/bancos/cecred/specs/segmento_t.json
@@ -120,7 +120,7 @@
     },
 
     "17.3T": {
-      "nome": "valor_titulo",
+      "nome": "valor_lancamento",
       "posicao_inicio": 82,
       "posicao_fim": 96,
       "formato": "num",

--- a/cnab240/bancos/cecred/specs/segmento_u.json
+++ b/cnab240/bancos/cecred/specs/segmento_u.json
@@ -140,7 +140,7 @@
     },
 
     "19.3U": {
-      "nome": "data_ocorrencia",
+      "nome": "vazio0",
       "posicao_inicio": 158,
       "posicao_fim": 165,
       "formato": "alfa"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='python3-cnab',
-    version='0.9.5',
+    version='0.9.6',
     author='Trustcode',
     author_email='suporte@trustcode.com.br',
     url='https://github.com/Trust-Code/python-cnab',


### PR DESCRIPTION
FIX JSON:
- tag 'valor-titulo' -> tag 'valor-lançamento';
- tag repetida 'data-ocorrencia' removida -> renamed to 'vazio0'