### PR TITLE
Correção nome campo segmento_s sicoob

### DIFF
--- a/cnab240/bancos/sicoob/specs/segmento_s.json
+++ b/cnab240/bancos/sicoob/specs/segmento_s.json
@@ -100,7 +100,7 @@
         },
 
         "14.3S": {
-            "nome": "controle_banco",
+            "nome": "vazio2",
             "posicao_inicio": 219,
             "posicao_fim": 240,
             "formato": "alfa",


### PR DESCRIPTION
Alterado o nome do campo do registro 14.3s, estava igual ao do registro 01.3s gerando erro na geração do arquivo.