### PR TITLE
Removido default de cedente_conta_dv

### DIFF
--- a/cnab240/bancos/sicoob/specs/header_arquivo.json
+++ b/cnab240/bancos/sicoob/specs/header_arquivo.json
@@ -80,8 +80,7 @@
             "nome": "cedente_conta_dv",
             "posicao_inicio": 71,
             "posicao_fim": 71,
-            "formato": "alfa",
-            "default": 0
+            "formato": "alfa"
         },
 
         "12.0": {


### PR DESCRIPTION
A valor default estava causando um erro na geração da remessa, por ser
do tipo inteiro, enquanto o formato esperado é alfa.